### PR TITLE
Fix handling of large files

### DIFF
--- a/wierd.c
+++ b/wierd.c
@@ -126,7 +126,8 @@ int main (int argc, char *argv[]) {
     y = 1;                              /* Read the file into the memoryspace */
     while (!feof (infile) && y < SIZE) {
         fscanf (infile, "%1023[^\n]", &workspace[y][1]);
-        fgetc (infile);
+        fscanf (infile, "%*[^\n]");     /* skip the rest of the line until \n */
+        fgetc (infile);                 /* skip \n */
         #ifdef DEBUG
         printf ("%s\n", &workspace[y][1]);
         #endif

--- a/wierd.c
+++ b/wierd.c
@@ -124,7 +124,7 @@ int main (int argc, char *argv[]) {
     }
 
     y = 1;                              /* Read the file into the memoryspace */
-    while (!feof (infile)) {
+    while (!feof (infile) && y < SIZE) {
         fscanf (infile, "%127[^\n]", &workspace[y][1]);
         fgetc (infile);
         #ifdef DEBUG

--- a/wierd.c
+++ b/wierd.c
@@ -44,7 +44,7 @@
 
 /* Constants and Macros */
 
-#define SIZE    128
+#define SIZE    1024                    /* keep in sync with "%1023[^\n]" */
 
 /*** Data Structures ***/
 
@@ -125,7 +125,7 @@ int main (int argc, char *argv[]) {
 
     y = 1;                              /* Read the file into the memoryspace */
     while (!feof (infile) && y < SIZE) {
-        fscanf (infile, "%127[^\n]", &workspace[y][1]);
+        fscanf (infile, "%1023[^\n]", &workspace[y][1]);
         fgetc (infile);
         #ifdef DEBUG
         printf ("%s\n", &workspace[y][1]);


### PR DESCRIPTION
Fixed segfault on large files (`SIZE` lines or more). 
Fixed handling of long lines (`SIZE` bytes or more), such lines were read as several lines. 
Also increased `SIZE`.